### PR TITLE
feat: add drag-and-drop quadrants classification

### DIFF
--- a/quadrants/index.html
+++ b/quadrants/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Quadrants de Tests – Association de cas</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet"/>
+    <link rel="stylesheet" href="styles.css"/>
+</head>
+<body>
+<header>
+    <h1>🧭 Quadrants de Tests</h1>
+    <p>Faites glisser chaque <strong>cas de test</strong> dans le <strong>quadrant approprié</strong>.</p>
+</header>
+
+<main>
+    <section class="grid-layout">
+        <div class="dropzone" data-quadrant="q1">Quadrant Q1<br><small>Automatisé, orienté technologie</small></div>
+        <div class="dropzone" data-quadrant="q2">Quadrant Q2<br><small>Automatisé, orienté métier</small></div>
+        <div class="dropzone" data-quadrant="q3">Quadrant Q3<br><small>Manuel, orienté métier</small></div>
+        <div class="dropzone" data-quadrant="q4">Quadrant Q4<br><small>Manuel, orienté technologie</small></div>
+    </section>
+
+    <section class="cards-container">
+        <!-- Cartes injectées dynamiquement -->
+    </section>
+
+    <div class="button-container">
+        <button onclick="validateMatches()">Valider</button>
+        <p id="feedback" class="feedback-msg"></p>
+    </div>
+</main>
+
+<script src="scripts.js"></script>
+</body>
+</html>

--- a/quadrants/scripts.js
+++ b/quadrants/scripts.js
@@ -1,0 +1,97 @@
+const cardsData = [
+    {
+        id: 'unit-test',
+        quadrant: 'q1',
+        text: 'Test unitaire sur une fonction critique'
+    },
+    {
+        id: 'api-test',
+        quadrant: 'q2',
+        text: 'Test fonctionnel automatisé d\'API'
+    },
+    {
+        id: 'exploratory-ui',
+        quadrant: 'q3',
+        text: 'Session de test exploratoire sur l\'interface'
+    },
+    {
+        id: 'load-test',
+        quadrant: 'q4',
+        text: 'Test de charge sur le serveur'
+    }
+];
+
+let draggedCard = null;
+
+function renderCards() {
+    const container = document.querySelector('.cards-container');
+    container.innerHTML = '';
+
+    cardsData.forEach(card => {
+        const div = document.createElement('div');
+        div.classList.add('card');
+        div.setAttribute('draggable', true);
+        div.setAttribute('id', card.id);
+        div.setAttribute('data-quadrant', card.quadrant);
+        div.textContent = card.text;
+
+        div.addEventListener('dragstart', () => {
+            draggedCard = div;
+            div.classList.add('dragged');
+        });
+
+        div.addEventListener('dragend', () => {
+            draggedCard = null;
+            div.classList.remove('dragged');
+        });
+
+        container.appendChild(div);
+    });
+}
+
+function setupDropzones() {
+    const zones = document.querySelectorAll('.dropzone');
+
+    zones.forEach(zone => {
+        zone.addEventListener('dragover', e => {
+            e.preventDefault();
+            zone.classList.add('hovered');
+        });
+
+        zone.addEventListener('dragleave', () => {
+            zone.classList.remove('hovered');
+        });
+
+        zone.addEventListener('drop', () => {
+            zone.classList.remove('hovered');
+            if (draggedCard) {
+                zone.appendChild(draggedCard);
+            }
+        });
+    });
+}
+
+function validateMatches() {
+    const zones = document.querySelectorAll('.dropzone');
+    let correct = 0;
+
+    zones.forEach(zone => {
+        const expected = zone.getAttribute('data-quadrant');
+        const card = zone.querySelector('.card');
+        if (card && card.getAttribute('data-quadrant') === expected) {
+            correct++;
+        }
+    });
+
+    const feedback = document.getElementById('feedback');
+    if (correct === cardsData.length) {
+        feedback.innerText = '✅ Bravo ! Tous les cas sont correctement classés.';
+        feedback.style.color = '#2ecc71';
+    } else {
+        feedback.innerText = '❌ Certains cas ne sont pas au bon endroit.';
+        feedback.style.color = '#e74c3c';
+    }
+}
+
+renderCards();
+setupDropzones();

--- a/quadrants/styles.css
+++ b/quadrants/styles.css
@@ -1,0 +1,94 @@
+body {
+    font-family: 'Inter', sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f9f9fc;
+    color: #333;
+}
+
+header {
+    background: linear-gradient(to right, #667eea, #764ba2);
+    color: white;
+    padding: 50px 20px;
+    text-align: center;
+}
+
+main {
+    padding: 30px 20px;
+    max-width: 1300px;
+    margin: auto;
+}
+
+.grid-layout {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.dropzone {
+    background-color: #e0e0e0;
+    border: 3px dashed #bbb;
+    padding: 20px;
+    min-height: 200px;
+    border-radius: 12px;
+    font-weight: bold;
+    text-align: center;
+    transition: background-color 0.3s;
+}
+
+.dropzone.hovered {
+    background-color: #d3d3f3;
+}
+
+.cards-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+}
+
+.card {
+    background: white;
+    border: 2px solid #ccc;
+    padding: 16px;
+    border-radius: 10px;
+    width: 280px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    cursor: grab;
+    transition: transform 0.2s ease;
+}
+
+.card:active {
+    cursor: grabbing;
+    transform: scale(1.02);
+}
+
+.card.dragged {
+    opacity: 0.5;
+}
+
+.button-container {
+    margin-top: 40px;
+    text-align: center;
+}
+
+button {
+    padding: 12px 30px;
+    font-size: 1rem;
+    background-color: #764ba2;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #5e3f8d;
+}
+
+.feedback-msg {
+    margin-top: 20px;
+    font-weight: bold;
+    font-size: 1.1rem;
+}


### PR DESCRIPTION
## Summary
- add structured HTML page for quadrants classification
- implement test cards and drag-and-drop logic
- style quadrants page to match existing theme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f6633c08322946e480bdc8f08b0