### PR TITLE
Shuffle cards before rendering

### DIFF
--- a/quadrants/scripts.js
+++ b/quadrants/scripts.js
@@ -23,9 +23,18 @@ const cardsData = [
 
 let draggedCard = null;
 
+function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+}
+
 function renderCards() {
     const container = document.querySelector('.cards-container');
     container.innerHTML = '';
+
+    shuffle(cardsData);
 
     cardsData.forEach(card => {
         const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- add Fisher-Yates shuffle to randomize card order
- shuffle `cardsData` each time cards render

## Testing
- `node --check quadrants/scripts.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b7396d2a148322863c4acb9258e545